### PR TITLE
Update README for consistent -loader suffix to reflect Webpack 2 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ console.log(appConfig.env) // 'production'
 ```
 #### Usage with require statement loader prefix
 ```js
-var appConfig = require("json5!./appData.json5")
+var appConfig = require("json5-loader!./appData.json5")
 // returns the content as json parsed object
 
 console.log(appConfig.env) // 'production'


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:
Doc changes
**What is the current behavior?** (You can also link to an open issue here)

The use of the `-loader` suffix in the README is not always present.

**What is the new behavior?**

With Webpack v2.1.0-beta.26, the `-loader` suffix is required for loaders. This PR makes it consistent across the README by adding the `-loader` suffix to the statement that is missing this naming.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following...

* Impact:
* Migration path for existing applications:
* Github Issue(s) this is regarding:


**Other information**:
